### PR TITLE
adding more laravel infrastructure and installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+Graceful Cache for Laravel 4
+================
+
+Tony should write a very salesy description of what this package is and why it is important.
+
+### Required setup
+
+In the `require` key of `composer.json` file add the following
+
+    "maherio/graceful-cache": "dev-master"
+
+Run the Composer update comand
+
+    $ composer update
+
+In your `config/app.php` add `'GracefulCache\ServiceProvider'` to the end of the `$providers` array
+
+```php
+'providers' => array(
+
+    'Illuminate\Foundation\Providers\ArtisanServiceProvider',
+    'Illuminate\Auth\AuthServiceProvider',
+    ...
+    'GracefulCache\ServiceProvider',
+
+),
+```
+

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
         {
             "name": "Tony Maher",
             "email": "amaher@alumni.nd.edu"
+        },
+        {
+            "name": "Steven Maguire",
+            "email": "stevenmaguire@gmail.com"
         }
     ],
     "minimum-stability": "dev",
@@ -21,7 +25,7 @@
     },
     "autoload": {
         "classmap": [
-            "src/GracefulCache/Repository"
+            "src/GracefulCache"
         ],
         "psr-0": {
             "GracefulCache": "src/GracefulCache"

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
-                "reference": "0d80e8f57521be6ce9a61c115e7177baed7880b3"
+                "reference": "834981f254d8f1ba798168c24dc0d0fe1a101720"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/cache/zipball/0d80e8f57521be6ce9a61c115e7177baed7880b3",
-                "reference": "0d80e8f57521be6ce9a61c115e7177baed7880b3",
+                "url": "https://api.github.com/repos/illuminate/cache/zipball/834981f254d8f1ba798168c24dc0d0fe1a101720",
+                "reference": "834981f254d8f1ba798168c24dc0d0fe1a101720",
                 "shasum": ""
             },
             "require": {
@@ -52,7 +52,8 @@
                     "email": "taylorotwell@gmail.com"
                 }
             ],
-            "time": "2014-09-30 13:42:10"
+            "description": "The Illuminate Cache package.",
+            "time": "2014-11-20 04:36:49"
         },
         {
             "name": "illuminate/contracts",
@@ -60,12 +61,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "ccbca49fb3dd5c4d98347b8936c8b36cea5c8686"
+                "reference": "1effd8824d8b3b7679e0ee9b332750647953f7c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/ccbca49fb3dd5c4d98347b8936c8b36cea5c8686",
-                "reference": "ccbca49fb3dd5c4d98347b8936c8b36cea5c8686",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/1effd8824d8b3b7679e0ee9b332750647953f7c0",
+                "reference": "1effd8824d8b3b7679e0ee9b332750647953f7c0",
                 "shasum": ""
             },
             "require": {
@@ -92,7 +93,8 @@
                     "email": "taylorotwell@gmail.com"
                 }
             ],
-            "time": "2014-10-25 19:01:42"
+            "description": "The Illuminate Contracts package.",
+            "time": "2014-11-29 19:55:20"
         },
         {
             "name": "illuminate/support",
@@ -100,12 +102,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "1d04d64fcfad0cda2c272fe721825909a3020d2d"
+                "reference": "eba26ed09f1040a99ab9760af5b72b7e35bf73d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/1d04d64fcfad0cda2c272fe721825909a3020d2d",
-                "reference": "1d04d64fcfad0cda2c272fe721825909a3020d2d",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/eba26ed09f1040a99ab9760af5b72b7e35bf73d7",
+                "reference": "eba26ed09f1040a99ab9760af5b72b7e35bf73d7",
                 "shasum": ""
             },
             "require": {
@@ -140,7 +142,8 @@
                     "email": "taylorotwell@gmail.com"
                 }
             ],
-            "time": "2014-10-26 02:56:00"
+            "description": "The Illuminate Support package.",
+            "time": "2014-12-03 02:41:40"
         },
         {
             "name": "nesbot/carbon",
@@ -196,12 +199,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/padraic/mockery.git",
-                "reference": "8e567de2249a8f7eb8051a855b9d0a6472d38c8e"
+                "reference": "4055c0e8577dfbc841fd384797487ff3fc75afff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/8e567de2249a8f7eb8051a855b9d0a6472d38c8e",
-                "reference": "8e567de2249a8f7eb8051a855b9d0a6472d38c8e",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/4055c0e8577dfbc841fd384797487ff3fc75afff",
+                "reference": "4055c0e8577dfbc841fd384797487ff3fc75afff",
                 "shasum": ""
             },
             "require": {
@@ -254,7 +257,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2014-10-16 09:15:15"
+            "time": "2014-11-18 13:37:25"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -632,17 +635,17 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "dev-master",
+            "version": "2.7.x-dev",
             "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "4c0baf9a5b5c9e50ddd7a46f3c75cb85baf5d6c5"
+                "reference": "610f01968f2cd731fdf59dfeae904ed930afc35f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4c0baf9a5b5c9e50ddd7a46f3c75cb85baf5d6c5",
-                "reference": "4c0baf9a5b5c9e50ddd7a46f3c75cb85baf5d6c5",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/610f01968f2cd731fdf59dfeae904ed930afc35f",
+                "reference": "610f01968f2cd731fdf59dfeae904ed930afc35f",
                 "shasum": ""
             },
             "require": {
@@ -651,7 +654,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
@@ -675,7 +678,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "http://symfony.com",
-            "time": "2014-10-26 07:46:28"
+            "time": "2014-12-02 20:19:50"
         }
     ],
     "aliases": [],

--- a/src/GracefulCache/CacheManager.php
+++ b/src/GracefulCache/CacheManager.php
@@ -1,0 +1,18 @@
+<?php namespace GracefulCache;
+
+use Illuminate\Cache\CacheManager as BaseCacheManager,
+    Illuminate\Cache\StoreInterface;
+
+class CacheManager extends BaseCacheManager
+{
+    /**
+     * Create a new cache repository with the given implementation.
+     *
+     * @param  \Illuminate\Cache\StoreInterface  $store
+     * @return \GracefulCache\Repository
+     */
+    protected function repository(StoreInterface $store)
+    {
+        return new Repository($store);
+    }
+}

--- a/src/GracefulCache/Repository.php
+++ b/src/GracefulCache/Repository.php
@@ -1,8 +1,8 @@
-<?php namespace GracefulCache\Repository;
+<?php namespace GracefulCache;
 
-use Illuminate\Cache\Repository;
+use Illuminate\Cache\Repository as BaseRepository;
 
-class GracefulCacheRepository extends Repository {
+class Repository extends BaseRepository {
 
     /**
      * The prefix of the string to be appended to each cache value. This is an added

--- a/src/GracefulCache/ServiceProvider.php
+++ b/src/GracefulCache/ServiceProvider.php
@@ -1,0 +1,26 @@
+<?php namespace GracefulCache;
+
+use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+
+class ServiceProvider extends BaseServiceProvider {
+
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = true;
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->bindShared('cache', function($app)
+        {
+            return new CacheManager($app);
+        });
+    }
+}

--- a/tests/GracefulCacheRepositoryTest.php
+++ b/tests/GracefulCacheRepositoryTest.php
@@ -1,4 +1,4 @@
-<?php namespace GracefulCache\Repository;
+<?php namespace GracefulCache;
 
 use PHPUnit_Framework_TestCase;
 use Mockery;
@@ -17,27 +17,27 @@ class GracefulCacheRepositoryTest extends PHPUnit_Framework_TestCase {
     //////////////////////
 
     public function testUpdateValue() {
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
 
         $originalValue = 'thisisatestvalue';
         $cacheLength = 10; //10 mins
         $newValue = $repository->getModifiedValue($originalValue, $cacheLength);
 
         $this->assertContains('thisisatestvalue', $newValue);
-        $this->assertContains(GracefulCacheRepository::$gracefulPrefix, $newValue);
+        $this->assertContains(Repository::$gracefulPrefix, $newValue);
     }
 
     public function testGetOriginalValue() {
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
 
-        $newValue = serialize('thisisatestvalue') . GracefulCacheRepository::$gracefulPrefix . '1111';
+        $newValue = serialize('thisisatestvalue') . Repository::$gracefulPrefix . '1111';
         $originalValue = $repository->getOriginalValue($newValue);
 
         $this->assertEquals('thisisatestvalue', $originalValue);
     }
 
     public function testGetOriginalValueFromOldCacheValue() {
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
 
         $newValue = 'thisisatestvalue';
         $originalValue = $repository->getOriginalValue($newValue);
@@ -46,16 +46,16 @@ class GracefulCacheRepositoryTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testExpirationTime() {
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
 
-        $newValue = 'thisisatestvalue' . GracefulCacheRepository::$gracefulPrefix . '1111';
+        $newValue = 'thisisatestvalue' . Repository::$gracefulPrefix . '1111';
         $expirationTime = $repository->getExpirationTime($newValue);
 
         $this->assertEquals('1111', $expirationTime);
     }
 
     public function testExpirationTimeFromOldCacheValue() {
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
 
         $newValue = 'thisisatestvalue';
         $expirationTime = $repository->getExpirationTime($newValue);
@@ -73,13 +73,13 @@ class GracefulCacheRepositoryTest extends PHPUnit_Framework_TestCase {
         $cacheLength = 10; //10 mins
 
         $expirationTime = time() + ($cacheLength * 60);
-        $modifiedValue = serialize($cacheValue) . GracefulCacheRepository::$gracefulPrefix . $expirationTime;
+        $modifiedValue = serialize($cacheValue) . Repository::$gracefulPrefix . $expirationTime;
 
         $this->cacheStoreMock->shouldReceive('put')
             ->with($cacheKey, $modifiedValue, $cacheLength)
             ->andReturn(true);
 
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
         $repository->put($cacheKey, $cacheValue, $cacheLength);
     }
 
@@ -91,13 +91,13 @@ class GracefulCacheRepositoryTest extends PHPUnit_Framework_TestCase {
         $cacheLength = 10; //10 minds
 
         $expirationTime = time() + ($cacheLength * 60);
-        $modifiedValue = serialize($cacheValue) . GracefulCacheRepository::$gracefulPrefix . $expirationTime;
+        $modifiedValue = serialize($cacheValue) . Repository::$gracefulPrefix . $expirationTime;
 
         $this->cacheStoreMock->shouldReceive('put')
             ->with($cacheKey, $modifiedValue, $cacheLength)
             ->andReturn(true);
 
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
         $repository->put($cacheKey, $cacheValue, $cacheLength);
     }
 
@@ -109,7 +109,7 @@ class GracefulCacheRepositoryTest extends PHPUnit_Framework_TestCase {
             ->with($cacheKey)
             ->andReturn(null);
 
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
 
         $value = $repository->get($cacheKey, $defaultValue);
         $this->assertEquals($defaultValue, $value);
@@ -124,13 +124,13 @@ class GracefulCacheRepositoryTest extends PHPUnit_Framework_TestCase {
         $cacheLength = 10; //10 mins
 
         $expirationTime = time() + ($cacheLength * 60);
-        $modifiedValue = serialize($cacheValue) . GracefulCacheRepository::$gracefulPrefix . $expirationTime;
+        $modifiedValue = serialize($cacheValue) . Repository::$gracefulPrefix . $expirationTime;
 
         $this->cacheStoreMock->shouldReceive('get')
             ->with($cacheKey)
             ->andReturn($modifiedValue);
 
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
         $returnedValue = $repository->get($cacheKey);
 
         $this->assertEquals($cacheValue, $returnedValue);
@@ -140,17 +140,17 @@ class GracefulCacheRepositoryTest extends PHPUnit_Framework_TestCase {
         $cacheKey = 'abcd';
         $cacheValue = 'thisisatestvalue';
         $cacheLength = 10; //10 mins
-        $expirationTime = time() + (GracefulCacheRepository::$extendMinutes * 60);
-        $modifiedValue = serialize($cacheValue) . GracefulCacheRepository::$gracefulPrefix . $expirationTime;
+        $expirationTime = time() + (Repository::$extendMinutes * 60);
+        $modifiedValue = serialize($cacheValue) . Repository::$gracefulPrefix . $expirationTime;
 
         $this->cacheStoreMock->shouldReceive('get')
             ->with($cacheKey)
             ->andReturn($cacheValue);
         $this->cacheStoreMock->shouldReceive('put')
-            ->with($cacheKey, $modifiedValue, GracefulCacheRepository::$extendMinutes)
+            ->with($cacheKey, $modifiedValue, Repository::$extendMinutes)
             ->andReturn(true);
 
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
         $returnedValue = $repository->get($cacheKey);
 
         //old values should return null from the cache, so they're updated with the new one
@@ -163,20 +163,20 @@ class GracefulCacheRepositoryTest extends PHPUnit_Framework_TestCase {
         $cacheLength = 0.1; //6 seconds
 
         $expirationTime = time() + ($cacheLength * 60);
-        $modifiedValue = serialize($cacheValue) . GracefulCacheRepository::$gracefulPrefix . $expirationTime;
+        $modifiedValue = serialize($cacheValue) . Repository::$gracefulPrefix . $expirationTime;
 
         $this->cacheStoreMock->shouldReceive('get')
             ->with($cacheKey)
             ->andReturn($modifiedValue);
 
-        $expirationTime = time() + (GracefulCacheRepository::$extendMinutes * 60);
-        $modifiedValue = serialize($cacheValue) . GracefulCacheRepository::$gracefulPrefix . $expirationTime;
+        $expirationTime = time() + (Repository::$extendMinutes * 60);
+        $modifiedValue = serialize($cacheValue) . Repository::$gracefulPrefix . $expirationTime;
 
         $this->cacheStoreMock->shouldReceive('put')
-            ->with($cacheKey, $modifiedValue, GracefulCacheRepository::$extendMinutes)
+            ->with($cacheKey, $modifiedValue, Repository::$extendMinutes)
             ->andReturn(true);
 
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
         $returnedValue = $repository->get($cacheKey);
 
         //it should be null for this request so the cache refreshes
@@ -191,13 +191,13 @@ class GracefulCacheRepositoryTest extends PHPUnit_Framework_TestCase {
         $cacheLength = 10; //10 mins
 
         $expirationTime = time() + ($cacheLength * 60);
-        $modifiedValue = serialize($cacheValue) . GracefulCacheRepository::$gracefulPrefix . $expirationTime;
+        $modifiedValue = serialize($cacheValue) . Repository::$gracefulPrefix . $expirationTime;
 
         $this->cacheStoreMock->shouldReceive('get')
             ->with($cacheKey)
             ->andReturn($modifiedValue);
 
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
         $returnedValue = $repository->get($cacheKey);
 
         $this->assertEquals($cacheValue, $returnedValue);
@@ -209,17 +209,17 @@ class GracefulCacheRepositoryTest extends PHPUnit_Framework_TestCase {
             'testKey' => 'thisisatestvalue'
         ];
         $cacheLength = 10; //10 mins
-        $expirationTime = time() + (GracefulCacheRepository::$extendMinutes * 60);
-        $modifiedValue = serialize($cacheValue) . GracefulCacheRepository::$gracefulPrefix . $expirationTime;
+        $expirationTime = time() + (Repository::$extendMinutes * 60);
+        $modifiedValue = serialize($cacheValue) . Repository::$gracefulPrefix . $expirationTime;
 
         $this->cacheStoreMock->shouldReceive('get')
             ->with($cacheKey)
             ->andReturn($cacheValue);
         $this->cacheStoreMock->shouldReceive('put')
-            ->with($cacheKey, $modifiedValue, GracefulCacheRepository::$extendMinutes)
+            ->with($cacheKey, $modifiedValue, Repository::$extendMinutes)
             ->andReturn(true);
 
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
         $returnedValue = $repository->get($cacheKey);
 
         //old values should return null so the cache is updated
@@ -234,20 +234,20 @@ class GracefulCacheRepositoryTest extends PHPUnit_Framework_TestCase {
         $cacheLength = 0.1; //6 seconds
 
         $expirationTime = time() + ($cacheLength * 60);
-        $modifiedValue = serialize($cacheValue) . GracefulCacheRepository::$gracefulPrefix . $expirationTime;
+        $modifiedValue = serialize($cacheValue) . Repository::$gracefulPrefix . $expirationTime;
 
         $this->cacheStoreMock->shouldReceive('get')
             ->with($cacheKey)
             ->andReturn($modifiedValue);
 
-        $expirationTime = time() + (GracefulCacheRepository::$extendMinutes * 60);
-        $modifiedValue = serialize($cacheValue) . GracefulCacheRepository::$gracefulPrefix . $expirationTime;
+        $expirationTime = time() + (Repository::$extendMinutes * 60);
+        $modifiedValue = serialize($cacheValue) . Repository::$gracefulPrefix . $expirationTime;
 
         $this->cacheStoreMock->shouldReceive('put')
-            ->with($cacheKey, $modifiedValue, GracefulCacheRepository::$extendMinutes)
+            ->with($cacheKey, $modifiedValue, Repository::$extendMinutes)
             ->andReturn(true);
 
-        $repository = new GracefulCacheRepository($this->cacheStoreMock);
+        $repository = new Repository($this->cacheStoreMock);
         $returnedValue = $repository->get($cacheKey);
 
         $this->assertNull($returnedValue);


### PR DESCRIPTION
I reorganized the classes a bit (sorry) and verified that the Repository tests still pass. The other changes are related to the efforts to make the package installation seamless. 

The short of the installation strategy is that the ServiceProvider replaces the IoC key `cache` with a GracefulCache version of the CacheManager, that extends the stock Laravel CacheManager. This child class overrides the `repository()` method to return an instance of the GracefulCache Repository instead of the stock Laravel Repository.

This implementation plan should extend this packages effectiveness to all drivers. The previous implementation plan requires that each driver be explicitly declared and return the GracefulCache Repository manually.

Fair warning, I am not sure if the timing of the providers is accurate, but I would give it a shot in your test environment and see how it performs. Let me know if there are other issues!
