### PR TITLE
adding support for custom drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Cache::extend('elasticache', function() {
     $servers = Config::get('cache.memcached');
     $elasticache = new Illuminate\Cache\ElasticacheConnector();
     $memcached = $elasticache->connect($servers);
-    return Cache::buildRepository(new Illuminate\Cache\MemcachedStore($memcached, Config::get('cache.prefix')));
+    return Cache::getRepository(new Illuminate\Cache\MemcachedStore($memcached, Config::get('cache.prefix')));
 });
 ```
 
-*The `buildRepository` method is provided by the GracefulCache package and is not supported by the Laravel framework.*
+*The `getRepository` method is provided by the GracefulCache package and is not supported by the Laravel framework.*

--- a/README.md
+++ b/README.md
@@ -26,3 +26,15 @@ In your `config/app.php` add `'GracefulCache\ServiceProvider'` to the end of the
 ),
 ```
 
+### Cache driver extensions
+
+```php
+Cache::extend('elasticache', function() {
+    $servers = Config::get('cache.memcached');
+    $elasticache = new Illuminate\Cache\ElasticacheConnector();
+    $memcached = $elasticache->connect($servers);
+    return Cache::buildRepository(new Illuminate\Cache\MemcachedStore($memcached, Config::get('cache.prefix')));
+});
+```
+
+*The `buildRepository` method is provided by the GracefulCache package and is not supported by the Laravel framework.*

--- a/src/GracefulCache/CacheManager.php
+++ b/src/GracefulCache/CacheManager.php
@@ -22,7 +22,7 @@ class CacheManager extends BaseCacheManager
      * @param  \Illuminate\Cache\StoreInterface  $store
      * @return \GracefulCache\Repository
      */
-    public function buildRepository(StoreInterface $store)
+    public function getRepository(StoreInterface $store)
     {
         return $this->repository($store);
     }

--- a/src/GracefulCache/CacheManager.php
+++ b/src/GracefulCache/CacheManager.php
@@ -15,4 +15,15 @@ class CacheManager extends BaseCacheManager
     {
         return new Repository($store);
     }
+
+    /**
+     * Create a new cache repository with the given implementation.
+     *
+     * @param  \Illuminate\Cache\StoreInterface  $store
+     * @return \GracefulCache\Repository
+     */
+    public function buildRepository(StoreInterface $store)
+    {
+        return $this->repository($store);
+    }
 }

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -1,0 +1,27 @@
+<?php namespace GracefulCache;
+
+use PHPUnit_Framework_TestCase;
+use Mockery;
+
+class CacheManagerTest extends PHPUnit_Framework_TestCase
+{
+    protected $appMock;
+    protected $cacheStoreMock;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->appMock = Mockery::mock('Illuminate\Contracts\Foundation\Application');
+        $this->cacheStoreMock = Mockery::mock('Illuminate\Cache\StoreInterface');
+    }
+
+    public function testBuildingRepository()
+    {
+        $manager = new CacheManager($this->appMock);
+        $repository = $manager->buildRepository($this->cacheStoreMock);
+
+        $this->assertTrue(is_subclass_of($repository, 'Illuminate\Cache\Repository'));
+        $this->assertEquals(get_class($repository), 'GracefulCache\Repository');
+    }
+
+}

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -18,7 +18,7 @@ class CacheManagerTest extends PHPUnit_Framework_TestCase
     public function testBuildingRepository()
     {
         $manager = new CacheManager($this->appMock);
-        $repository = $manager->buildRepository($this->cacheStoreMock);
+        $repository = $manager->getRepository($this->cacheStoreMock);
 
         $this->assertTrue(is_subclass_of($repository, 'Illuminate\Cache\Repository'));
         $this->assertEquals(get_class($repository), 'GracefulCache\Repository');


### PR DESCRIPTION
After reviewing the code that I wrote yesterday, it is clear that while the changes I proposed do allow the "built in" cache drivers to utilize the graceful cache, it does not address your original elasticache use case which involves manually creating a new GracefulCache\Repository in your driver. 

So, the changes I proposed are good for using your class to help with built in drivers, but doesn't really help your elasticache use case. 

I have added a bit more code and some documentation in the README to help address this. The CacheManager child class overrides the parent class method for creating the Repository object which is protected. I added a public method in the child class to permit access to this method. 

Take a look at the README and the code changes. Let me know how that goes.
